### PR TITLE
Add support for setting global configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Currently, only Redhat and derivates are supported.
         'netbios-name-servers' => [ $::ipaddress_eth0 ],
         'domain-name'          => $::domain,
       },
+      config            => {
+        'server-identifier' => $::ipaddress,
+        'log-facility'      => 'local6',
+      },
       include           => [
         '/etc/dhcpd.conf.others',
         '/etc/named-dhcpd.key',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,10 @@
 #      'domain-name-servers'  => [ '8.8.8.8', '8.8.4.4' ],
 #      'netbios-name-servers' => [ '1.2.3.4' ],
 #    },
+#    config            => {
+#      'server-identifier' => $::ipaddress,
+#      'log-facility'      => 'local6',
+#    },
 #    include           => [
 #      '/etc/dhcpd.conf.printers',
 #      '/etc/dhcpd.conf.others',
@@ -32,6 +36,7 @@
 class dhcpd::config(
 $config_file       = '',
 $options           = {},
+$config            = {},
 $include           = [],
 $ddns_domainname   = '',
 $ddns_update_style = '',

--- a/templates/dhcpd_global.conf.erb
+++ b/templates/dhcpd_global.conf.erb
@@ -3,6 +3,15 @@ authoritative;
 <% end -%>
 
 # Global configuration follows
+<% @config.sort.map do |confname,confvalue| -%>
+<% if confvalue.is_a?(Array) -%>
+<%= confname %> <%= confvalue.join(",") %>;
+<% else -%>
+<%= confname %> <%= confvalue %>;
+<% end -%>
+<% end -%>
+
+# DHCP options follow
 <% @options.sort.map do |optname,optvalue| -%>
 <% if optvalue.is_a?(Array) -%>
 option <%= optname %> <%= optvalue.join(",") %>;


### PR DESCRIPTION
Add support for setting global configuration options, e.g. `server-identifier` and `log-facility`
