### PR TITLE
Test config before restarting service

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,6 +51,7 @@ $authoritative     = undef,
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
+    notify  => Exec['dhcpd-config-test'],
   }
 
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,20 @@
 class dhcpd::service {
   include dhcpd::params
   service { $::dhcpd::params::service_name:
-    ensure => running,
-    enable => true,
+    ensure     => running,
+    enable     => true,
+    hasstatus  => true,
+    hasrestart => true,
   }
+
+  # This exec tests the dhcpd config and fails if it's bad
+  # It isn't run every time puppet runs, but only when dhcpd is to be restarted
+  exec { 'dhcpd-config-test':
+    command     => '/usr/bin/sudo /usr/sbin/dhcpd -q -t',
+    returns     => 0,
+    refreshonly => true,
+    logoutput   => on_failure,
+    notify      => Service[$::dhcpd::params::service_name],
+  }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,7 +11,7 @@ class dhcpd::service {
   # This exec tests the dhcpd config and fails if it's bad
   # It isn't run every time puppet runs, but only when dhcpd is to be restarted
   exec { 'dhcpd-config-test':
-    command     => '/usr/bin/sudo /usr/sbin/dhcpd -q -t',
+    command     => '/usr/sbin/dhcpd -q -t',
     returns     => 0,
     refreshonly => true,
     logoutput   => on_failure,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -5,6 +5,7 @@ class dhcpd::service {
     enable     => true,
     hasstatus  => true,
     hasrestart => true,
+    require    => Exec['dhcpd-config-test'],
   }
 
   # This exec tests the dhcpd config and fails if it's bad


### PR DESCRIPTION
Test config before restarting service. If a bad config is accidentally deployed, the exec will fail and the service will not be stopped.
