### PR TITLE
Lint fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently, only Redhat and derivates are supported.
 DDNS updates are supported, but you still have to manage security key (through the inclusion of an external file)
 * include statement allows you to add external managed files
 * options hash configuration global dhcpd options
-* omapi supported through omapi_ items
+* omapi supported through omapi_items
 
 Supported DHCP items:
 * class
@@ -53,6 +53,7 @@ Supported DHCP items:
 * pool
 * ranges
 * shared-network
+* failover
 
 ### Example of dhcp class
 
@@ -122,6 +123,7 @@ Supported DHCP items:
       'domain-name'         => 'shared1-example.com',
     },
     shared_network_name  => 'workstations-and-printers',
+    failover_peer        => 'dhcp-srv',
   }
   dhcpd::subnet { 'shared subnet 2':
     network => '192.168.102.0',
@@ -141,6 +143,7 @@ Supported DHCP items:
       },
     },
     shared_network_name  => 'workstations-and-printers',
+    failover_peer        => 'dhcp-srv',
   }
 ```
   
@@ -153,3 +156,25 @@ Supported DHCP items:
   }
 ```
 
+### Configuration of DHCP failover
+
+Use this class to configure DHCP failover. For full details of what these parameters do, refer to the
+[ISC DHCP documentation](https://kb.isc.org/article/AA-00502/31/A-Basic-Guide-to-Configuring-DHCP-Failover.html).
+
+Most of these parameters have sensible defaults but you **must** provide a value for `peer`, `primary`, and `peer_address`.
+
+```
+  class { 'dhcpd::failover':
+    peer                     => 'dhcp-srv',
+    primary                  => true,
+    address                  => $::fqdn,
+    port                     => 647,
+    peer_address             => 'dhcp-srv2.example.com',
+    peer_port                => 647,
+    max_response_delay       => 60,
+    max_unacked_updates      => 10,
+    load_balance_max_seconds => 3,
+    mclt                     => 1800,
+    split                    => 128,
+  }
+```

--- a/manifests/append.pp
+++ b/manifests/append.pp
@@ -1,6 +1,6 @@
 define dhcpd::append(
 $config_file           = '',
-$content               = ,
+$content               = undef,
 $order                 = '99',
 ) {
   include dhcpd::params

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,10 +48,10 @@ $authoritative     = undef,
   include dhcpd::params
 
   concat { $config_file:
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
-    notify  => Exec['dhcpd-config-test'],
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    notify => Exec['dhcpd-config-test'],
   }
 
 

--- a/manifests/failover.pp
+++ b/manifests/failover.pp
@@ -1,0 +1,33 @@
+class dhcpd::failover (
+  $peer,
+  $primary,
+  $peer_address,
+  $address = $::fqdn,
+  $port = 647,
+  $peer_port = 647,
+  $max_response_delay = 60,
+  $max_unacked_updates = 10,
+  $load_balance_max_seconds = 3,
+  $mclt = 1800,
+  $split = 128,
+) {
+
+  # Validate our inputs
+  validate_string($peer)
+  validate_bool($primary)
+  validate_string($address)
+  validate_integer($port)
+  validate_string($peer_address)
+  validate_integer($peer_port)
+  validate_integer($max_response_delay)
+  validate_integer($max_unacked_updates)
+  validate_integer($load_balance_max_seconds)
+  validate_integer($mclt)
+  validate_integer($split)
+
+  concat::fragment { 'dhcpd_failover':
+    content => template('dhcpd/dhcpd_failover.conf.erb'),
+    target  => $dhcpd::config_file,
+    order   => '04'
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,5 +60,5 @@ $global_config       = {},
   $config_params = { 'dhcpd::config' => merge($global_config, {config_file => $config_file}) }
   create_resources( 'class', $config_params)
 
-  Class['dhcpd::config'] ~> Class ['dhcpd::service']
+  Class['dhcpd::config'] ~> Class['dhcpd::service']
 }

--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -10,12 +10,13 @@ $allow_dynamic_bootp_clients   = false,
 $deny_dynamic_bootp_clients    = false,
 $allow_all_clients             = false,
 $deny_all_clients              = false,
-$default_lease_time            = '',
-$max_lease_time                = '',
+$default_lease_time            = undef,
+$max_lease_time                = undef,
 $ranges                        = [],
 $order                         = '10',
 $subnet_name                   = undef,
 $shared_network_name           = 'global',
+$failover_peer                 = undef,
 ) {
   include dhcpd::params
 

--- a/manifests/subnet.pp
+++ b/manifests/subnet.pp
@@ -15,6 +15,7 @@ $allow_client_updates      = false,
 $update_conflict_detection = false,
 $disable_ddns_updates      = false,
 $shared_network_name       = 'global',
+$failover_peer             = undef,
 ) {
   include dhcpd::params
 
@@ -34,7 +35,7 @@ $shared_network_name       = 'global',
     order   => $order,
   }
   if $pools {
-    create_resources(dhcpd::pool, $pools, {config_file => $config_file, order => $order, subnet_name => $name, shared_network_name => $shared_network_name})
+    create_resources(dhcpd::pool, $pools, {config_file => $config_file, order => $order, subnet_name => $name, shared_network_name => $shared_network_name, failover_peer => $failover_peer})
   }
   concat::fragment { "${_shared_network_name}_2_${_subnet_name}_subnet_3":
     content => template('dhcpd/dhcpd_subnet_end.conf.erb'),

--- a/metadata.json
+++ b/metadata.json
@@ -2,24 +2,35 @@
   "name": "davidb-dhcpd",
   "version": "0.2.0",
   "author": "davidb",
-  "license": "Apache License, Version 2.0",
   "summary": "An isc-dhcpd module",
+  "license": "Apache-2.0",
   "source": "https://github.com/david-barbion/puppet-dhcpd",
   "project_page": "https://forge.puppetlabs.com/davidb/dhcpd",
   "issues_url": "https://github.com/david-barbion/puppet-dhcpd/issues",
-  "tags": ["isc-dhcpd", "dhcp"],
   "dependencies": [
-    {"name": "puppetlabs-concat", "version_requirement": ">= 1.1.0"},
-    {"name": "puppetlabs-stdlib", "version_requirement": ">= 4.2.2"}
+    {"name":"puppetlabs-concat","version_requirement":">= 1.1.0 < 2.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.2.2 < 5.0.0"}
+  ],
+  "tags": [
+    "isc-dhcpd",
+    "dhcp"
   ],
   "operatingsystem_support": [
     {
-    "operatingsystem":"RedHat",
-    "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     },
     {
-    "operatingsystem": "CentOS",
-    "operatingsystemrelease":[ "5.0", "6.0", "7.0" ]
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "5",
+        "6",
+        "7"
+      ]
     }
   ]
 }

--- a/templates/dhcpd_failover.conf.erb
+++ b/templates/dhcpd_failover.conf.erb
@@ -1,0 +1,13 @@
+# Failover config
+failover peer "<%= @peer %>" {
+        <% if @primary = true %>primary<% else %>secondary<% end %>;
+        address <%= @address %>;
+        port <%= @port %>;
+        peer address <%= @peer_address %>;
+        peer port <%= @peer_port %>;
+        max-response-delay <%= @max_response_delay %>;
+        max-unacked-updates <%= @max_unacked_updates %>;
+        load balance max seconds <%= @load_balance_max_seconds %>;
+        mclt <%= @mclt %>;
+        split <%= @split %>;
+}

--- a/templates/dhcpd_subnet_pool.conf.erb
+++ b/templates/dhcpd_subnet_pool.conf.erb
@@ -10,6 +10,9 @@
 <%= @front_spaces %>    deny members of "<%= member %>";
 <%end%>
 <% end -%>
+<% if @failover_peer -%>
+<%= @front_spaces %>    failover peer "<%= @failover_peer %>";
+<% end -%>
 <% if @allow_known_clients == true -%>
 <%= @front_spaces %>    allow known-clients;
 <%end-%>


### PR DESCRIPTION
A number of trivial fixes to improve code quality, improve rating on Puppet Forge and increase compatibility with Puppet 4
- Fix indentation to comply with lint checking
- Small syntax fixes to work with future parser
- Fix license formatting
- Provide bounds for version numbers
- Improve formatting of metadata.json
- Define integer version numbers of RedHat/CentOS releases, since the point releases don't make a difference and could cause confusion
